### PR TITLE
[REFACTOR] Extract HOC from render.

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,6 +15,9 @@ const SEARCH_ENDPOINT = '/search';
 const PARAM_SEARCH = 'query=';
 const PARAM_PAGE = 'page=';
 
+// HOC for button with loading throbber.
+const ButtonWithLoading = withLoading(Button);
+
 class App extends Component {
   constructor(props) {
     super(props);
@@ -153,9 +156,6 @@ class App extends Component {
     const list =
       (results && results[searchKey] && results[searchKey].hits) || [];
 
-    // HOC for button with loading throbber.
-    const ButtonWithLoading = withLoading(Button);
-
     return (
       <div className="c-page">
         <div className="interactions">
@@ -176,9 +176,10 @@ class App extends Component {
         )}
 
         <div className="interactions">
-          <ButtonWithLoading 
+          <ButtonWithLoading
             isLoading={isLoading}
-            onClick={() => this.fetchSearchTopStories(searchKey, page + 1)}>
+            onClick={() => this.fetchSearchTopStories(searchKey, page + 1)}
+          >
             More
           </ButtonWithLoading>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 
-// This addition is allowing to reload page modules without browser refresh.
+// Reload page modules without browser refresh.
 if (module.hot) {
-    module.hot.accept();
+  module.hot.accept();
 }
 
 registerServiceWorker();


### PR DESCRIPTION
## Overview of change(s)

- [**Trello ticket**](https://trello.com/)

### Description of change(s)
It's a bad practise to use HOC inside of the render method due to few reasons. Performance, as component will be redefined each time render is called as well as remounting a component causes the state of that component and all of its children to be lost.

### Screenshots
~
### Pre-merge checklist

- [~] Have you added _**unit tests**_ where needed?
- [~] What about _**functional tests**_?
